### PR TITLE
Make free_threads! support tuples

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "PolyesterWeave"
 uuid = "1d0040c9-8b98-4ee7-8388-3f51789ca0ad"
 authors = ["Chris Elrod <elrodc@gmail.com> and contributors"]
-version = "0.1.7"
+version = "0.1.8"
 
 [deps]
 BitTwiddlingConvenienceFunctions = "62783981-4cbd-42fc-bca8-16325de8dc4b"

--- a/src/request.jl
+++ b/src/request.jl
@@ -29,7 +29,7 @@ function free_threads!(freed_threads_tuple::NTuple{N, U}) where {N,U<:Unsigned}
   wp = worker_pointer()
   for freed_threads in freed_threads_tuple
     _atomic_or!(wp, freed_threads)
-    wp += 8
+    wp += sizeof(worker_pointer_type())
   end
   nothing
 end

--- a/src/request.jl
+++ b/src/request.jl
@@ -25,7 +25,7 @@ function free_threads!(freed_threads_tuple::NTuple{1, U}) where {U<:Unsigned}
   _atomic_or!(worker_pointer(), freed_threads_tuple[1])
   nothing
 end
-function free_threads!(freed_threads_tuple::NTuple{N, U}) where {N,U<:Unsigned}
+function free_threads!(freed_threads_tuple::Tuple{U, Vararg{U, N}}) where {N,U<:Unsigned}
   wp = worker_pointer()
   for freed_threads in freed_threads_tuple
     _atomic_or!(wp, freed_threads)


### PR DESCRIPTION
Previously `free_threads!` only affected the first 64 threads. This change allows to correctly free all threads by giving it the tuple of threads to release returned by `request_threads`.

The previous behavior is kept, but it might be preferable to remove it entirely.