### PR TITLE
Remove CPUSummary dependence

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,18 +1,16 @@
 name = "PolyesterWeave"
 uuid = "1d0040c9-8b98-4ee7-8388-3f51789ca0ad"
 authors = ["Chris Elrod <elrodc@gmail.com> and contributors"]
-version = "0.1.11"
+version = "0.1.12"
 
 [deps]
 BitTwiddlingConvenienceFunctions = "62783981-4cbd-42fc-bca8-16325de8dc4b"
-CPUSummary = "2a0fbf3d-bb9c-48f3-b0a9-814d99fd7ab9"
 IfElse = "615f187c-cbe4-4ef1-ba3b-2fcf58d6d173"
 Static = "aedffcd0-7271-4cad-89d0-dc628f76c6d3"
 ThreadingUtilities = "8290d209-cae3-49c0-8002-c8c24d57dab5"
 
 [compat]
 BitTwiddlingConvenienceFunctions = "0.1"
-CPUSummary = "0.1.2"
 IfElse = "0.1"
 Static = "0.3.1, 0.4, 0.5, 0.6, 0.7, 0.8"
 ThreadingUtilities = "0.4.5, 0.5"

--- a/src/PolyesterWeave.jl
+++ b/src/PolyesterWeave.jl
@@ -4,7 +4,6 @@ using BitTwiddlingConvenienceFunctions: nextpow2
 using ThreadingUtilities: _atomic_store!, _atomic_or!, _atomic_xchg!
 using Static
 using IfElse: ifelse
-using CPUSummary: num_threads
 
 export request_threads, free_threads!
 
@@ -29,6 +28,12 @@ const WORKERS = Ref{NTuple{8,UInt64}}(ntuple(((zero ∘ UInt64)), Val(8)))
 
 include("unsignediterator.jl")
 include("request.jl")
+
+# Consider removing this from Polyester and PolyesterWeave on the next breaking release
+# It is exported by Polyester, so we can not just delete it without a breaking release.
+# Previously we used CPUSummary.num_threads which caused significant
+# TTFX problems due to it being redefined inside of CPUSummary.__init__
+const num_threads = Threads.nthreads
 
 dynamic_thread_count() = min((Sys.CPU_THREADS)::Int, Threads.nthreads())
 function worker_mask_init(x)


### PR DESCRIPTION
A non-static stub to replace `CPUSummary.num_threads` is made. The reason we are using a stub instead of outright removing `num_threads` is that `Polyester` exports that symbol. We could consider a breaking release which would be a bit cleaner (no stub necessary, directly switching to `Threads.nthreads`).

This would fix https://github.com/JuliaSIMD/Polyester.jl/issues/95