### PR TITLE
RFC: more than 64 threads

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "PolyesterWeave"
 uuid = "1d0040c9-8b98-4ee7-8388-3f51789ca0ad"
 authors = ["Chris Elrod <elrodc@gmail.com> and contributors"]
-version = "0.1.12"
+version = "0.1.13"
 
 [deps]
 BitTwiddlingConvenienceFunctions = "62783981-4cbd-42fc-bca8-16325de8dc4b"


### PR DESCRIPTION
Follow up on 

- https://github.com/JuliaRegistries/General/pull/74745
- https://buildkite.com/julialang/ordinarydiffeq-dot-jl/builds/1790#0185596c-f7d5-4364-988c-410cf30e74d8
- https://github.com/SciML/OrdinaryDiffEq.jl/pull/1824#issuecomment-1366911453

This is a "cargo cult" of a solution. I really do not know what I am doing right now and I do not have a machine on which to test this in order to familiarize myself with Polyester, so any guidance would be appreciated.

Tangentially: I hoped that I can simply test it with `julia -t120` on my 16-thread cpu, but that causes test failures on any version of Polyester and PolyesterWeave (not only the newest, flawed ones).