### PR TITLE
run tests with more than 64 cpu threads

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -17,6 +17,16 @@ jobs:
           - ubuntu-latest
         arch:
           - x64
+        juliacputhreads:
+          - 1
+          - 5
+          - 80
+        juliathreads:
+          - 1
+          - 4
+          - 10
+          - 70
+          - 90
     steps:
       - uses: actions/checkout@v2
       - uses: julia-actions/setup-julia@v1
@@ -35,6 +45,9 @@ jobs:
             ${{ runner.os }}-
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
+        env:
+          JULIA_NUM_THREADS: ${{ matrix.juliathreads }}
+          JULIA_CPU_THREADS: ${{ matrix.juliacputhreads }}
   docs:
     name: Documentation
     runs-on: ubuntu-latest

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -4,7 +4,7 @@ on:
   - pull_request
 jobs:
   test:
-    name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ github.event_name }}
+    name: Julia ${{ matrix.version }} - cputhreads=${{ matrix.juliacputhreads }} juliathreads=${{ matrix.juliathreads }} - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ github.event_name }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false

--- a/Project.toml
+++ b/Project.toml
@@ -1,16 +1,18 @@
 name = "PolyesterWeave"
 uuid = "1d0040c9-8b98-4ee7-8388-3f51789ca0ad"
 authors = ["Chris Elrod <elrodc@gmail.com> and contributors"]
-version = "0.1.12"
+version = "0.1.13"
 
 [deps]
 BitTwiddlingConvenienceFunctions = "62783981-4cbd-42fc-bca8-16325de8dc4b"
+CPUSummary = "2a0fbf3d-bb9c-48f3-b0a9-814d99fd7ab9"
 IfElse = "615f187c-cbe4-4ef1-ba3b-2fcf58d6d173"
 Static = "aedffcd0-7271-4cad-89d0-dc628f76c6d3"
 ThreadingUtilities = "8290d209-cae3-49c0-8002-c8c24d57dab5"
 
 [compat]
 BitTwiddlingConvenienceFunctions = "0.1"
+CPUSummary = "0.1.2"
 IfElse = "0.1"
 Static = "0.3.1, 0.4, 0.5, 0.6, 0.7, 0.8"
 ThreadingUtilities = "0.4.5, 0.5"

--- a/src/request.jl
+++ b/src/request.jl
@@ -1,6 +1,8 @@
+import CPUSummary
+
 function worker_bits()
-  wts = nextpow2(num_threads())
-  ws = static(8sizeof(UInt))
+  wts = nextpow2(CPUSummary.sys_threads()) # Typically sys_threads (i.e. Sys.CPU_THREADS) does not change between runs, thus it will precompile well.
+  ws = static(8sizeof(UInt))               # For testing purposes it can be overridden by JULIA_CPU_THREADS,
   ifelse(Static.lt(wts,ws), ws, wts)
 end
 function worker_mask_count()
@@ -90,4 +92,3 @@ end
   _request_threads(num_requested % UInt32, worker_pointer(), worker_mask_count(), threadmask)
 end
 @inline request_threads(num_requested) = request_threads(num_requested, nothing)
-

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -6,7 +6,7 @@ using Test
   threads, torelease = PolyesterWeave.request_threads(Threads.nthreads()-1)
   @test threads isa NTuple{Int(PolyesterWeave.worker_mask_count()),PolyesterWeave.UnsignedIteratorEarlyStop{UInt}}
   @test sum(map(length, threads)) == (PolyesterWeave.num_threads())-1
-  map(PolyesterWeave.free_threads!, torelease)
+  PolyesterWeave.free_threads!(torelease)
 
   r1 = PolyesterWeave.request_threads(Sys.CPU_THREADS, 0x0a)
   @test (r1[2][1] & 0x0a) == r1[2][1]
@@ -14,11 +14,10 @@ using Test
   @test (r2[2][1] & 0xff) == r2[2][1]
   @test count_ones(r1[2][1] ⊻ r2[2][1]) ≤ min(8, Sys.CPU_THREADS)
   @test iszero(r1[2][1] & r2[2][1])
-  PolyesterWeave.free_threads!(r1[2][1]); PolyesterWeave.free_threads!(r2[2][1])
-  
+  PolyesterWeave.free_threads!(r1[2]); PolyesterWeave.free_threads!(r2[2])
+
   @testset "Valid State" begin
     @test sum(map(count_ones, PolyesterWeave.WORKERS[])) == min(512, PolyesterWeave.dynamic_thread_count() - 1)
   end
 end
 Aqua.test_all(PolyesterWeave)
-

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,3 +1,6 @@
+println(
+  "Starting tests with $(Threads.nthreads()) threads out of `Sys.CPU_THREADS = $(Sys.CPU_THREADS)`...",
+)
 using PolyesterWeave, Aqua
 using Test
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -8,7 +8,7 @@ using Test
 
   threads, torelease = PolyesterWeave.request_threads(Threads.nthreads()-1)
   @test threads isa NTuple{Int(PolyesterWeave.worker_mask_count()),PolyesterWeave.UnsignedIteratorEarlyStop{UInt}}
-  @test sum(map(length, threads)) == (PolyesterWeave.num_threads())-1
+  @test sum(map(length, threads)) == (min(Sys.CPU_THREADS,PolyesterWeave.num_threads()))-1
   PolyesterWeave.free_threads!(torelease)
 
   r1 = PolyesterWeave.request_threads(Sys.CPU_THREADS, 0x0a)


### PR DESCRIPTION
This fixes the following test failure on v0.1.11

```
(ppp) pkg> add PolyesterWeave@0.1.11
    Updating registry at `~/.julia/registries/General.toml`
   Resolving package versions...
    Updating `/tmp/ppp/Project.toml`
⌃ [1d0040c9] + PolyesterWeave v0.1.11
    Updating `/tmp/ppp/Manifest.toml`
  [62783981] + BitTwiddlingConvenienceFunctions v0.1.5
  [2a0fbf3d] + CPUSummary v0.1.30
  [adafc99b] + CpuId v0.3.1
  [615f187c] + IfElse v0.1.1
  [d125e4d3] + ManualMemory v0.1.8
⌃ [1d0040c9] + PolyesterWeave v0.1.11
  [aedffcd0] + Static v0.8.3
  [8290d209] + ThreadingUtilities v0.5.0
  [2a0f44e3] + Base64
  [d6f4376e] + Markdown
        Info Packages marked with ⌃ have new versions available

julia> versioninfo()
Julia Version 1.8.0
Commit 5544a0fab76 (2022-08-17 13:38 UTC)
Platform Info:
  OS: Linux (x86_64-linux-gnu)
  CPU: 16 × AMD Ryzen 7 1700 Eight-Core Processor
  WORD_SIZE: 64
  LIBM: libopenlibm
  LLVM: libLLVM-13.0.1 (ORCJIT, znver1)
  Threads: 100 on 111 virtual cores
Environment:
  JULIA_CPU_THREADS = 111

julia> Threads.nthreads()
100

julia> Sys.CPU_THREADS
111

(ppp) pkg> test PolyesterWeave
     Testing PolyesterWeave
      Status `/tmp/jl_QYN5qf/Project.toml`
  [4c88cf16] Aqua v0.6.0
  [62783981] BitTwiddlingConvenienceFunctions v0.1.5
  [2a0fbf3d] CPUSummary v0.1.30
  [615f187c] IfElse v0.1.1
⌃ [1d0040c9] PolyesterWeave v0.1.11
  [aedffcd0] Static v0.8.3
  [8290d209] ThreadingUtilities v0.5.0
  [8dfed614] Test `@stdlib/Test`
      Status `/tmp/jl_QYN5qf/Manifest.toml`
  [4c88cf16] Aqua v0.6.0
  [62783981] BitTwiddlingConvenienceFunctions v0.1.5
  [2a0fbf3d] CPUSummary v0.1.30
  [34da2185] Compat v4.5.0
  [adafc99b] CpuId v0.3.1
  [615f187c] IfElse v0.1.1
  [d125e4d3] ManualMemory v0.1.8
⌃ [1d0040c9] PolyesterWeave v0.1.11
  [aedffcd0] Static v0.8.3
  [8290d209] ThreadingUtilities v0.5.0
  [0dad84c5] ArgTools v1.1.1 `@stdlib/ArgTools`
  [56f22d72] Artifacts `@stdlib/Artifacts`
  [2a0f44e3] Base64 `@stdlib/Base64`
  [ade2ca70] Dates `@stdlib/Dates`
  [f43a241f] Downloads v1.6.0 `@stdlib/Downloads`
  [7b1f6079] FileWatching `@stdlib/FileWatching`
  [b77e0a4c] InteractiveUtils `@stdlib/InteractiveUtils`
  [b27032c2] LibCURL v0.6.3 `@stdlib/LibCURL`
  [76f85450] LibGit2 `@stdlib/LibGit2`
  [8f399da3] Libdl `@stdlib/Libdl`
  [37e2e46d] LinearAlgebra `@stdlib/LinearAlgebra`
  [56ddb016] Logging `@stdlib/Logging`
  [d6f4376e] Markdown `@stdlib/Markdown`
  [ca575930] NetworkOptions v1.2.0 `@stdlib/NetworkOptions`
  [44cfe95a] Pkg v1.8.0 `@stdlib/Pkg`
  [de0858da] Printf `@stdlib/Printf`
  [3fa0cd96] REPL `@stdlib/REPL`
  [9a3f8284] Random `@stdlib/Random`
  [ea8e919c] SHA v0.7.0 `@stdlib/SHA`
  [9e88b42a] Serialization `@stdlib/Serialization`
  [6462fe0b] Sockets `@stdlib/Sockets`
  [fa267f1f] TOML v1.0.0 `@stdlib/TOML`
  [a4e569a6] Tar v1.10.0 `@stdlib/Tar`
  [8dfed614] Test `@stdlib/Test`
  [cf7118a7] UUIDs `@stdlib/UUIDs`
  [4ec0a83e] Unicode `@stdlib/Unicode`
  [e66e0078] CompilerSupportLibraries_jll v0.5.2+0 `@stdlib/CompilerSupportLibraries_jll`
  [deac9b47] LibCURL_jll v7.84.0+0 `@stdlib/LibCURL_jll`
  [29816b5a] LibSSH2_jll v1.10.2+0 `@stdlib/LibSSH2_jll`
  [c8ffd9c3] MbedTLS_jll v2.28.0+0 `@stdlib/MbedTLS_jll`
  [14a3606d] MozillaCACerts_jll v2022.2.1 `@stdlib/MozillaCACerts_jll`
  [4536629a] OpenBLAS_jll v0.3.20+0 `@stdlib/OpenBLAS_jll`
  [83775a58] Zlib_jll v1.2.12+3 `@stdlib/Zlib_jll`
  [8e850b90] libblastrampoline_jll v5.1.1+0 `@stdlib/libblastrampoline_jll`
  [8e850ede] nghttp2_jll v1.48.0+0 `@stdlib/nghttp2_jll`
  [3f19e933] p7zip_jll v17.4.0+0 `@stdlib/p7zip_jll`
        Info Packages marked with ⌃ have new versions available
     Testing Running tests...
Valid State: Test Failed at /home/stefan/.julia/packages/PolyesterWeave/RJIj7/test/runtests.jl:20
  Expression: sum(map(count_ones, PolyesterWeave.WORKERS[])) == min(512, PolyesterWeave.dynamic_thread_count() - 1)
   Evaluated: 64 == 99
Stacktrace:
 [1] macro expansion
   @ ~/.julia/juliaup/julia-1.8.0+0.x64/share/julia/stdlib/v1.8/Test/src/Test.jl:464 [inlined]
 [2] macro expansion
   @ ~/.julia/packages/PolyesterWeave/RJIj7/test/runtests.jl:20 [inlined]
 [3] macro expansion
   @ ~/.julia/juliaup/julia-1.8.0+0.x64/share/julia/stdlib/v1.8/Test/src/Test.jl:1357 [inlined]
 [4] macro expansion
   @ ~/.julia/packages/PolyesterWeave/RJIj7/test/runtests.jl:20 [inlined]
 [5] macro expansion
   @ ~/.julia/juliaup/julia-1.8.0+0.x64/share/julia/stdlib/v1.8/Test/src/Test.jl:1357 [inlined]
 [6] top-level scope
   @ ~/.julia/packages/PolyesterWeave/RJIj7/test/runtests.jl:6
Test Summary:     | Pass  Fail  Total  Time
PolyesterWeave.jl |    6     1      7  0.8s
  Valid State     |          1      1  0.6s
ERROR: LoadError: Some tests did not pass: 6 passed, 1 failed, 0 errored, 0 broken.
in expression starting at /home/stefan/.julia/packages/PolyesterWeave/RJIj7/test/runtests.jl:4
ERROR: Package PolyesterWeave errored during testing
```

This was incorrectly reported in #9, where I misunderstood the root cause of the issue.

A probably excessive set of CI test configurations were added.

If this is on the right track, I will plan to follow up with actually fixing #8 