### PR TITLE
master-main branch name confusion in CI

### DIFF
--- a/.github/workflows/Downstream.yml
+++ b/.github/workflows/Downstream.yml
@@ -1,7 +1,7 @@
 name: IntegrationTest
 on:
   push:
-    branches: [master]
+    branches: [main]
     tags: [v*]
   pull_request:
 


### PR DESCRIPTION
I think this was copied over from a repo that had `master` as default branch, while this repo was created after git/github switched to `main` as default, which cause the CI to be skipped on merge.