### PR TITLE
Remove use of `CPUSummary`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -5,14 +5,12 @@ version = "0.2.2"
 
 [deps]
 BitTwiddlingConvenienceFunctions = "62783981-4cbd-42fc-bca8-16325de8dc4b"
-CPUSummary = "2a0fbf3d-bb9c-48f3-b0a9-814d99fd7ab9"
 IfElse = "615f187c-cbe4-4ef1-ba3b-2fcf58d6d173"
 Static = "aedffcd0-7271-4cad-89d0-dc628f76c6d3"
 ThreadingUtilities = "8290d209-cae3-49c0-8002-c8c24d57dab5"
 
 [compat]
 BitTwiddlingConvenienceFunctions = "0.1"
-CPUSummary = "0.1.2, 0.2"
 IfElse = "0.1"
 Static = "0.3.1, 0.4, 0.5, 0.6, 0.7, 0.8, 1"
 ThreadingUtilities = "0.4.5, 0.5"

--- a/src/request.jl
+++ b/src/request.jl
@@ -1,7 +1,5 @@
-import CPUSummary
-
 function worker_bits()
-  wts = nextpow2(CPUSummary.sys_threads()) # Typically sys_threads (i.e. Sys.CPU_THREADS) does not change between runs, thus it will precompile well.
+  wts = nextpow2(Threads.nthreads()) # Typically sys_threads (i.e. Sys.CPU_THREADS) does not change between runs, thus it will precompile well.
   ws = static(8sizeof(UInt))               # For testing purposes it can be overridden by JULIA_CPU_THREADS,
   ifelse(Static.lt(wts, ws), ws, wts)
 end


### PR DESCRIPTION
The use of CPUInfo makes `--trim` difficult.
Removing this dependency here would unlock a large amount of libraries which use the Polyester library to be trimmmable (notably e.g. almost everything in the SciML ecosystem).

However, we might need a bit more discussion on the exact removal of this feature.